### PR TITLE
fix: remove request from path

### DIFF
--- a/packages/flamingo/src/model/route.ts
+++ b/packages/flamingo/src/model/route.ts
@@ -114,7 +114,7 @@ class Route {
     error,
     operation?: FlamingoOperation
   ) {
-    const message = `${error.name}: ${error.message} at '${request.path}'`;
+    const message = `${error.name}: ${error.message}`;
     logger.error(
       {
         error,


### PR DESCRIPTION
It's kinda useless as we're already exposing it via the request as error metadata.
Currently it's causing flamingo-sentry to generate a unique sentry log errors which could be grouped.